### PR TITLE
Mask negative values of ribbons

### DIFF
--- a/examples/optimizersplot.jl
+++ b/examples/optimizersplot.jl
@@ -43,6 +43,7 @@ sp3 = OrderedDict(
 p = optimizersplot(sp1, sp2, sp3,
                    estimator = :mean,
                    ylabel = "Cost",
+                   yscale = :log10,
                    )
 
 savefig(p, "example_plot.pdf")

--- a/src/include/optimizersplot.jl
+++ b/src/include/optimizersplot.jl
@@ -32,6 +32,10 @@ function build_subplot(data_dict, estimator)
     i = 0
     for (key, val) in data_dict
         fc, area = get_statistics(val, estimator)
+
+        # Mask negative ribbon values
+        @. area[1][@. area[1] < eps() ] = eps()
+
         # plot!(p, 0:(length(fc)-1), fc,
         plot!(p, fc,
               # xlims=(0, (length(fc)-1)),

--- a/src/include/optimizersplot.jl
+++ b/src/include/optimizersplot.jl
@@ -38,9 +38,8 @@ function build_subplot(data_dict, estimator)
 
         # plot!(p, 0:(length(fc)-1), fc,
         plot!(p, fc,
-              # xlims=(0, (length(fc)-1)),
               xlims=(1, length(fc)),
-              linewidth = 2,
+              linewidth=2,
               fillrange=area,
               fillalpha=0.4,
               label=key,


### PR DESCRIPTION
- mask negative ribbon values
- consistency
- example: show plots with logarithmic yscale
